### PR TITLE
fix: 修复ref的value监听的问题

### DIFF
--- a/src/reactivity/ref.js
+++ b/src/reactivity/ref.js
@@ -19,14 +19,14 @@ class RefImpl {
     this._val = convert(val)
   }
   get value() {
-    track(this, 'value')
+    track(this, 'get', 'value')
     return this._val
   }
 
   set value(val) {
     if (val !== this._val) {
       this._val = convert(val)
-      trigger(this, 'value')
+      trigger(this, 'set', 'value')
     }
   }
 }


### PR DESCRIPTION
trigger和track都是三个参数的，第二个参数是type。
trigger和track刚好都没传type，所以targetMap里面的key实际是是undefined